### PR TITLE
Support 202 Accepted as a valid success response code

### DIFF
--- a/src/pytest_openapi/contract.py
+++ b/src/pytest_openapi/contract.py
@@ -735,8 +735,15 @@ def test_get_endpoint(
 
     # Get the expected response from examples or generate from schema
     responses = operation.get("responses", {})
-    response_200 = responses.get("200", {})
+    response_200 = (
+        responses.get("200", {})
+        or responses.get("201", {})
+        or responses.get("202", {})
+    )
     content = response_200.get("content", {})
+    expected_status = (
+        202 if "202" in responses else (201 if "201" in responses else 200)
+    )
 
     # Get all documented response status codes
     documented_statuses = set()
@@ -773,7 +780,7 @@ def test_get_endpoint(
     if expected_response is None:
         return (
             False,
-            "No example found for 200 response. Examples are required.",
+            "No example found for 200/201/202 response. Examples are required.",
         )
 
     # Make the GET request
@@ -798,7 +805,9 @@ def test_get_endpoint(
 
     # Check status code
     actual_response = (
-        response.json() if response.status_code == 200 else response.text
+        response.json()
+        if response.status_code in [200, 201, 202]
+        else response.text
     )
 
     # In lenient mode, accept any documented status code
@@ -841,7 +850,7 @@ def test_get_endpoint(
                 "GET",
                 path,
                 None,
-                200,
+                expected_status,
                 expected_response,
                 response.status_code,
                 actual_response,
@@ -856,7 +865,7 @@ def test_get_endpoint(
                 "GET",
                 path,
                 None,
-                200,
+                expected_status,
                 expected_response,
                 response.status_code,
                 actual_response,
@@ -873,7 +882,7 @@ def test_get_endpoint(
             "GET",
             path,
             None,
-            200,
+            expected_status,
             expected_response,
             response.status_code,
             actual_response,
@@ -884,16 +893,16 @@ def test_get_endpoint(
         )
         return True, None
 
-    if response.status_code != 200:
+    if response.status_code != expected_status:
         error_msg = (
-            f"Expected status 200, got {response.status_code}. "
+            f"Expected status {expected_status}, got {response.status_code}. "
             f"Response: {response.text}"
         )
         log_test_result(
             "GET",
             path,
             None,
-            200,
+            expected_status,
             expected_response,
             response.status_code,
             actual_response,
@@ -1895,9 +1904,9 @@ def test_delete_endpoint(
     expected_status = None
     expected_body = None
 
-    for status_code in ["200", "204", "404"]:
+    for status_code in ["200", "201", "202", "204", "404"]:
         resp_obj = responses.get(status_code, {})
-        if status_code in ["200", "204"]:
+        if status_code in ["200", "201", "202", "204"]:
             expected_status = int(status_code)
         content = resp_obj.get("content", {})
         for media_type, media_obj in content.items():
@@ -2149,13 +2158,19 @@ def test_post_endpoint_single(
 
     # Get expected response
     responses = operation.get("responses", {})
-    response_200 = responses.get("200", {}) or responses.get("201", {})
+    response_200 = (
+        responses.get("200", {})
+        or responses.get("201", {})
+        or responses.get("202", {})
+    )
     content = response_200.get("content", {})
 
     expected_response = None
     response_schema = None
     response_is_example_based = False
-    expected_status = 201 if "201" in responses else 200
+    expected_status = (
+        202 if "202" in responses else (201 if "201" in responses else 200)
+    )
 
     # Get all documented response status codes
     documented_statuses = set()
@@ -2185,7 +2200,7 @@ def test_post_endpoint_single(
     if expected_response is None:
         return (
             False,
-            "No example found for 200/201 response. Examples are required.",
+            "No example found for 200/201/202 response. Examples are required.",
         )
 
     # Resolve path parameters using response example values
@@ -2320,8 +2335,8 @@ def test_post_endpoint_single(
 
     if is_streaming:
         # Streaming responses are valid - we can't validate their
-        # content in the same way. Just verify we got a 200/201.
-        if response.status_code in [200, 201]:
+        # content in the same way. Just verify we got a 200/201/202.
+        if response.status_code in [200, 201, 202]:
             log_test_result(
                 "POST",
                 path,
@@ -2369,8 +2384,8 @@ def test_post_endpoint_single(
 
     if is_streaming:
         # Streaming responses are valid - we can't validate their
-        # content in the same way. Just verify we got a 200/201.
-        if response.status_code in [200, 201]:
+        # content in the same way. Just verify we got a 200/201/202.
+        if response.status_code in [200, 201, 202]:
             log_test_result(
                 "POST",
                 path,
@@ -2407,7 +2422,9 @@ def test_post_endpoint_single(
 
     # Check status code
     actual_response = (
-        response.json() if response.status_code in [200, 201] else response.text
+        response.json()
+        if response.status_code in [200, 201, 202]
+        else response.text
     )
 
     # In lenient mode, accept any documented status code
@@ -2489,9 +2506,14 @@ def test_post_endpoint_single(
         )
         return True, None
 
-    if response.status_code not in [200, 201]:
+    valid_success_statuses = {
+        s for s in documented_statuses if s in {200, 201, 202}
+    }
+    if not valid_success_statuses:
+        valid_success_statuses = {200, 201, 202}
+    if response.status_code not in valid_success_statuses:
         error_msg = (
-            f"Expected status 200/201, got {response.status_code}. "
+            f"Expected status {expected_status}, got {response.status_code}. "
             f"Response: {response.text}"
         )
         log_test_result(
@@ -2585,13 +2607,20 @@ def test_put_endpoint_single(
     """
     # Get expected response first to extract path parameter values
     responses = operation.get("responses", {})
-    response_200 = responses.get("200", {}) or responses.get("204", {})
+    response_200 = (
+        responses.get("200", {})
+        or responses.get("201", {})
+        or responses.get("202", {})
+        or responses.get("204", {})
+    )
     content = response_200.get("content", {})
 
     expected_response = None
     response_schema = None
     response_is_example_based = False
-    expected_status = 200
+    expected_status = (
+        202 if "202" in responses else (201 if "201" in responses else 200)
+    )
 
     # Get all documented response status codes
     documented_statuses = set()
@@ -2621,7 +2650,7 @@ def test_put_endpoint_single(
     if expected_response is None:
         return (
             False,
-            "No example found for 200 response. Examples are required.",
+            "No example found for 200/201/202 response. Examples are required.",
         )
 
     # Resolve path parameters with values from the response example
@@ -2669,7 +2698,9 @@ def test_put_endpoint_single(
 
     # Check status code
     actual_response = (
-        response.json() if response.status_code == 200 else response.text
+        response.json()
+        if response.status_code in [200, 201, 202]
+        else response.text
     )
 
     # In lenient mode, accept any documented status code
@@ -2751,9 +2782,14 @@ def test_put_endpoint_single(
         )
         return True, None
 
-    if response.status_code != 200:
+    valid_success_statuses = {
+        s for s in documented_statuses if s in {200, 201, 202}
+    }
+    if not valid_success_statuses:
+        valid_success_statuses = {200, 201, 202}
+    if response.status_code not in valid_success_statuses:
         error_msg = (
-            f"Expected status 200, got {response.status_code}. "
+            f"Expected status {expected_status}, got {response.status_code}. "
             f"Response: {response.text}"
         )
         log_test_result(

--- a/tests/docker-compose.yaml
+++ b/tests/docker-compose.yaml
@@ -337,6 +337,32 @@ services:
           cpus: '0.1'
           memory: 128M
 
+  mock-server-post-202-accepted:
+    build:
+      context: test_servers/post_202_accepted
+      dockerfile: Dockerfile
+    image: mock-server-post-202-accepted:latest
+    ports:
+      - "8027:8000"
+    deploy:
+      resources:
+        limits:
+          cpus: '0.1'
+          memory: 128M
+
+  mock-server-post-202-returns-200:
+    build:
+      context: test_servers/post_202_returns_200
+      dockerfile: Dockerfile
+    image: mock-server-post-202-returns-200:latest
+    ports:
+      - "8028:8000"
+    deploy:
+      resources:
+        limits:
+          cpus: '0.1'
+          memory: 128M
+
   test:
     build:
       context: ..

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1596,3 +1596,99 @@ def test_openapi311_const_keyword_validated():
     assert (
         result.returncode == 0
     ), f"Expected /version const-keyword test to pass, got: {output}"
+
+
+@pytest.mark.depends(on=["test_openapi_flag_is_recognized"])
+def test_post_202_accepted_passes():
+    """Test that a POST endpoint documented and returning 202 Accepted passes.
+
+    Regression test for the bug where the plugin required a 200 or 201 example
+    and failed with 'No example found for 200/201 response' even when the spec
+    correctly documented a 202 Accepted response.
+    """
+    print("\n🔍 Testing POST endpoint with 202 Accepted response...", flush=True)
+    time.sleep(0.5)
+
+    result = subprocess.run(
+        [
+            "pytest",
+            "--openapi=http://mock-server-post-202-accepted:8000",
+            "-v",
+        ],
+        capture_output=True,
+        text=True,
+        cwd="/app",
+    )
+
+    output = result.stdout + result.stderr
+    assert (
+        result.returncode == 0
+    ), f"Expected 202 Accepted endpoints to pass, got: {output}"
+    assert (
+        "✅ OpenAPI spec validated successfully" in output
+    ), f"Expected validation success, got: {output}"
+    assert (
+        "test_openapi[POST /jobs" in output
+    ), f"Expected POST /jobs test item, got: {output}"
+
+
+@pytest.mark.depends(on=["test_openapi_flag_is_recognized"])
+def test_get_202_accepted_passes():
+    """Test that a GET endpoint documented and returning 202 Accepted passes."""
+    print("\n🔍 Testing GET endpoint with 202 Accepted response...", flush=True)
+    time.sleep(0.5)
+
+    result = subprocess.run(
+        [
+            "pytest",
+            "--openapi=http://mock-server-post-202-accepted:8000",
+            "-k",
+            "jobs/",
+            "-v",
+        ],
+        capture_output=True,
+        text=True,
+        cwd="/app",
+    )
+
+    output = result.stdout + result.stderr
+    assert (
+        result.returncode == 0
+    ), f"Expected GET 202 Accepted endpoint to pass, got: {output}"
+    assert (
+        "test_openapi[GET /jobs/" in output
+    ), f"Expected GET /jobs/{{job_id}} test item, got: {output}"
+
+
+@pytest.mark.depends(on=["test_openapi_flag_is_recognized"])
+def test_post_202_spec_but_server_returns_200_fails():
+    """Test that a POST endpoint documented as 202 but returning 200 is detected as a failure.
+
+    Regression test: the status check must respect what the spec documents.
+    When only 202 is documented, a server returning 200 is a contract violation
+    and should cause the test to fail.
+    """
+    print(
+        "\n🔍 Testing POST 202-documented endpoint that returns 200 (should fail)...",
+        flush=True,
+    )
+    time.sleep(0.5)
+
+    result = subprocess.run(
+        [
+            "pytest",
+            "--openapi=http://mock-server-post-202-returns-200:8000",
+            "-v",
+        ],
+        capture_output=True,
+        text=True,
+        cwd="/app",
+    )
+
+    output = result.stdout + result.stderr
+    assert (
+        result.returncode != 0
+    ), f"Expected failure when server returns 200 but spec documents 202, got: {output}"
+    assert (
+        "202" in output or "200" in output
+    ), f"Expected error mentioning the status code mismatch, got: {output}"

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1606,7 +1606,9 @@ def test_post_202_accepted_passes():
     and failed with 'No example found for 200/201 response' even when the spec
     correctly documented a 202 Accepted response.
     """
-    print("\n🔍 Testing POST endpoint with 202 Accepted response...", flush=True)
+    print(
+        "\n🔍 Testing POST endpoint with 202 Accepted response...", flush=True
+    )
     time.sleep(0.5)
 
     result = subprocess.run(

--- a/tests/test_servers/post_202_accepted/Dockerfile
+++ b/tests/test_servers/post_202_accepted/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.11-slim
+WORKDIR /app
+RUN pip install flask
+COPY server.py .
+CMD ["python", "server.py"]

--- a/tests/test_servers/post_202_accepted/server.py
+++ b/tests/test_servers/post_202_accepted/server.py
@@ -1,0 +1,121 @@
+"""Mock server where POST and GET endpoints respond with 202 Accepted."""
+
+from flask import Flask, jsonify, request
+
+app = Flask(__name__)
+
+
+@app.route("/openapi.json")
+def openapi():
+    """Return OpenAPI spec with 202 Accepted responses."""
+    return jsonify(
+        {
+            "openapi": "3.0.0",
+            "info": {"title": "202 Accepted API", "version": "1.0.0"},
+            "paths": {
+                "/jobs": {
+                    "post": {
+                        "summary": "Submit a background job",
+                        "requestBody": {
+                            "required": True,
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "type": "object",
+                                        "required": ["task"],
+                                        "properties": {
+                                            "task": {
+                                                "type": "string",
+                                                "description": "Task name to run",
+                                            }
+                                        },
+                                    },
+                                    "example": {"task": "generate-report"},
+                                }
+                            },
+                        },
+                        "responses": {
+                            "202": {
+                                "description": "Job accepted and queued",
+                                "content": {
+                                    "application/json": {
+                                        "schema": {
+                                            "type": "object",
+                                            "properties": {
+                                                "job_id": {
+                                                    "type": "string",
+                                                    "description": "Unique job identifier",
+                                                },
+                                                "status": {
+                                                    "type": "string",
+                                                    "description": "Initial job status",
+                                                },
+                                            },
+                                        },
+                                        "example": {
+                                            "job_id": "abc-123",
+                                            "status": "queued",
+                                        },
+                                    }
+                                },
+                            }
+                        },
+                    }
+                },
+                "/jobs/{job_id}": {
+                    "get": {
+                        "summary": "Check job status",
+                        "parameters": [
+                            {
+                                "name": "job_id",
+                                "in": "path",
+                                "required": True,
+                                "schema": {"type": "string"},
+                            }
+                        ],
+                        "responses": {
+                            "202": {
+                                "description": "Job is still processing",
+                                "content": {
+                                    "application/json": {
+                                        "schema": {
+                                            "type": "object",
+                                            "properties": {
+                                                "job_id": {
+                                                    "type": "string",
+                                                    "description": "Job identifier",
+                                                },
+                                                "status": {
+                                                    "type": "string",
+                                                    "description": "Current job status",
+                                                },
+                                            },
+                                        },
+                                        "example": {
+                                            "job_id": "abc-123",
+                                            "status": "processing",
+                                        },
+                                    }
+                                },
+                            }
+                        },
+                    }
+                },
+            },
+        }
+    )
+
+
+@app.route("/jobs", methods=["POST"])
+def submit_job():
+    data = request.get_json()
+    return jsonify({"job_id": "abc-123", "status": "queued"}), 202
+
+
+@app.route("/jobs/<job_id>", methods=["GET"])
+def get_job(job_id):
+    return jsonify({"job_id": job_id, "status": "processing"}), 202
+
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=8000)

--- a/tests/test_servers/post_202_returns_200/Dockerfile
+++ b/tests/test_servers/post_202_returns_200/Dockerfile
@@ -1,0 +1,5 @@
+FROM python:3.11-slim
+WORKDIR /app
+RUN pip install flask
+COPY server.py .
+CMD ["python", "server.py"]

--- a/tests/test_servers/post_202_returns_200/server.py
+++ b/tests/test_servers/post_202_returns_200/server.py
@@ -1,0 +1,63 @@
+"""Mock server that documents 202 Accepted but incorrectly returns 200 OK."""
+
+from flask import Flask, jsonify, request
+
+app = Flask(__name__)
+
+
+@app.route("/openapi.json")
+def openapi():
+    return jsonify(
+        {
+            "openapi": "3.0.0",
+            "info": {"title": "202 Mismatch API", "version": "1.0.0"},
+            "paths": {
+                "/jobs": {
+                    "post": {
+                        "summary": "Submit a background job",
+                        "requestBody": {
+                            "required": True,
+                            "content": {
+                                "application/json": {
+                                    "schema": {
+                                        "type": "object",
+                                        "required": ["task"],
+                                        "properties": {
+                                            "task": {
+                                                "type": "string",
+                                                "description": "Task name to run",
+                                            }
+                                        },
+                                    },
+                                    "example": {"task": "generate-report"},
+                                }
+                            },
+                        },
+                        "responses": {
+                            "202": {
+                                "description": "Job accepted and queued",
+                                "content": {
+                                    "application/json": {
+                                        "example": {
+                                            "job_id": "abc-123",
+                                            "status": "queued",
+                                        }
+                                    }
+                                },
+                            }
+                        },
+                    }
+                }
+            },
+        }
+    )
+
+
+@app.route("/jobs", methods=["POST"])
+def submit_job():
+    # Bug: spec says 202 but server returns 200
+    return jsonify({"job_id": "abc-123", "status": "queued"}), 200
+
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=8000)

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -1,6 +1,7 @@
 import os
 import json
 import time
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -388,3 +389,195 @@ def test_contains_invalid_enum_value():
 
     assert not contains_invalid_enum_value(schema_array, ["red", "blue"])
     assert contains_invalid_enum_value(schema_array, ["red", "yellow"])
+
+
+def _make_mock_response(status_code, json_body=None, text=""):
+    """Helper to create a mock requests.Response."""
+    mock = MagicMock()
+    mock.status_code = status_code
+    mock.text = text if json_body is None else json.dumps(json_body)
+    mock.headers = {"Content-Type": "application/json"}
+    mock.json.return_value = json_body
+    return mock
+
+
+def _post_operation_202():
+    """Return an OpenAPI operation object that documents a 202 response."""
+    return {
+        "requestBody": {
+            "required": True,
+            "content": {
+                "application/json": {
+                    "schema": {"type": "object"},
+                    "example": {"input": "value"},
+                }
+            },
+        },
+        "responses": {
+            "202": {
+                "description": "Accepted",
+                "content": {
+                    "application/json": {
+                        "example": {"status": "queued"},
+                    }
+                },
+            }
+        },
+    }
+
+
+def test_post_endpoint_single_accepts_202():
+    """test_post_endpoint_single should succeed when the spec and server both use 202."""
+    from pytest_openapi.contract import test_post_endpoint_single
+
+    mock_response = _make_mock_response(202, {"status": "queued"})
+    with patch(
+        "pytest_openapi.contract.make_request", return_value=mock_response
+    ):
+        success, error = test_post_endpoint_single(
+            base_url="http://fake",
+            path="/evaluate",
+            operation=_post_operation_202(),
+            request_body={"input": "value"},
+            test_origin="example",
+        )
+
+    assert success, f"Expected success for 202 response, got error: {error}"
+    assert error is None
+
+
+def test_post_endpoint_single_finds_202_example():
+    """When only a 202 response is documented, the plugin uses its example.
+
+    compare_responses checks keys and types but not scalar values, so a body
+    with matching structure passes even if the string values differ.  A genuine
+    failure (wrong status family like 4xx/5xx) still fails.
+    """
+    from pytest_openapi.contract import test_post_endpoint_single
+
+    # Server returns a 4xx — this should fail regardless of the spec status code
+    mock_response = _make_mock_response(400, None, text="Bad Request")
+    with patch(
+        "pytest_openapi.contract.make_request", return_value=mock_response
+    ):
+        success, error = test_post_endpoint_single(
+            base_url="http://fake",
+            path="/evaluate",
+            operation=_post_operation_202(),
+            request_body={"input": "value"},
+            test_origin="example",
+        )
+
+    assert not success
+    assert error is not None
+
+
+def test_post_endpoint_single_prefers_200_over_202():
+    """When both 200 and 202 are documented, 200 example takes priority."""
+    from pytest_openapi.contract import test_post_endpoint_single
+
+    operation = {
+        "requestBody": {
+            "required": True,
+            "content": {
+                "application/json": {
+                    "example": {"input": "value"},
+                }
+            },
+        },
+        "responses": {
+            "200": {
+                "description": "OK",
+                "content": {
+                    "application/json": {
+                        "example": {"result": "done"},
+                    }
+                },
+            },
+            "202": {
+                "description": "Accepted",
+                "content": {
+                    "application/json": {
+                        "example": {"status": "queued"},
+                    }
+                },
+            },
+        },
+    }
+
+    mock_response = _make_mock_response(200, {"result": "done"})
+    with patch(
+        "pytest_openapi.contract.make_request", return_value=mock_response
+    ):
+        success, error = test_post_endpoint_single(
+            base_url="http://fake",
+            path="/items",
+            operation=operation,
+            request_body={"input": "value"},
+            test_origin="example",
+        )
+
+    assert success, f"Expected success for 200 when both 200/202 documented: {error}"
+
+
+def test_get_endpoint_accepts_202():
+    """test_get_endpoint should succeed when the spec and server both use 202."""
+    from pytest_openapi.contract import test_get_endpoint
+
+    operation = {
+        "responses": {
+            "202": {
+                "description": "Accepted",
+                "content": {
+                    "application/json": {
+                        "example": {"status": "queued"},
+                    }
+                },
+            }
+        }
+    }
+
+    mock_response = _make_mock_response(202, {"status": "queued"})
+    with patch(
+        "pytest_openapi.contract.make_request", return_value=mock_response
+    ):
+        success, error = test_get_endpoint(
+            base_url="http://fake",
+            path="/status",
+            operation=operation,
+        )
+
+    assert success, f"Expected success for GET 202 response, got: {error}"
+
+
+def test_post_endpoint_single_no_202_example_fails():
+    """When no 200/201/202 example exists at all, the function should fail with a clear error."""
+    from pytest_openapi.contract import test_post_endpoint_single
+
+    operation = {
+        "requestBody": {
+            "required": True,
+            "content": {"application/json": {"example": {"x": 1}}},
+        },
+        "responses": {
+            "400": {
+                "description": "Bad Request",
+                "content": {
+                    "application/json": {
+                        "example": {"error": "bad input"},
+                    }
+                },
+            }
+        },
+    }
+
+    success, error = test_post_endpoint_single(
+        base_url="http://fake",
+        path="/items",
+        operation=operation,
+        request_body={"x": 1},
+        test_origin="example",
+    )
+
+    assert not success
+    assert "200/201/202" in error

--- a/tests/test_unit.py
+++ b/tests/test_unit.py
@@ -517,7 +517,9 @@ def test_post_endpoint_single_prefers_200_over_202():
             test_origin="example",
         )
 
-    assert success, f"Expected success for 200 when both 200/202 documented: {error}"
+    assert (
+        success
+    ), f"Expected success for 200 when both 200/202 documented: {error}"
 
 
 def test_get_endpoint_accepts_202():


### PR DESCRIPTION
## Summary

- Extends response-code handling in `contract.py` to recognise **202 Accepted** alongside 200/201 in all four HTTP methods (GET, POST, PUT, DELETE)
- `expected_status` is now derived from the spec (202 > 201 > 200) instead of being hardcoded
- Status validation now intersects against `documented_statuses`, so a server returning 200 when the spec only documents 202 is caught as a contract violation
- Adds two test servers: `post_202_accepted` (correct) and `post_202_returns_200` (wrong status — should fail)
- Integration and unit tests cover both scenarios

## Test plan

- [ ] `test_post_202_accepted_passes` — server documents and returns 202, expect pass
- [ ] `test_get_202_accepted_passes` — GET endpoint with 202, expect pass
- [ ] `test_post_202_spec_but_server_returns_200_fails` — spec says 202 but server returns 200, expect failure
- [ ] Existing suite passes unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)